### PR TITLE
hardcode the os field to Android

### DIFF
--- a/analytics/src/main/java/com/bluetriangle/analytics/Timer.java
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Timer.java
@@ -67,6 +67,7 @@ public class Timer implements Parcelable {
         DEFAULT_VALUES = new HashMap<>(40);
         DEFAULT_VALUES.put(FIELD_BVZN, "");
         DEFAULT_VALUES.put(FIELD_OS, "Android");
+        DEFAULT_VALUES.put(FIELD_NATIVE_OS, "Android");
         DEFAULT_VALUES.put(FIELD_EVENT_TYPE, "9");
         DEFAULT_VALUES.put(FIELD_NAVIGATION_TYPE, "9");
         DEFAULT_VALUES.put(FIELD_RV, "0");

--- a/analytics/src/main/java/com/bluetriangle/analytics/Tracker.java
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Tracker.java
@@ -143,7 +143,6 @@ public class Tracker {
         globalFields.put(Timer.FIELD_BROWSER, BROWSER);
         final String os = String.format("Android %s", Build.VERSION.RELEASE);
         final String appVersion = Utils.getAppVersion(context);
-        globalFields.put(Timer.FIELD_NATIVE_OS, os);
         final boolean isTablet = context.getResources().getBoolean(R.bool.isTablet);
         globalFields.put(Timer.FIELD_DEVICE, isTablet ? "Tablet" : "Mobile");
         globalFields.put(Timer.FIELD_BROWSER_VERSION, String.format("%s-%s-%s", BROWSER, appVersion, os));


### PR DESCRIPTION
Sets the default value for the `os` field to `Android` and do not update that value in the global fields when creating a tracker.