### PR TITLE
Crash timer field updates

### DIFF
--- a/analytics/src/main/java/com/bluetriangle/analytics/Constants.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Constants.kt
@@ -5,6 +5,7 @@ package com.bluetriangle.analytics
  */
 object Constants {
     const val OS = "Android"
+    const val CRASH_PAGE_NAME = "Android Crash"
     const val BROWSER = "Native App"
     const val DEVICE_TABLET = "Tablet"
     const val DEVICE_MOBILE = "Mobile"

--- a/analytics/src/main/java/com/bluetriangle/analytics/CrashRunnable.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/CrashRunnable.kt
@@ -43,6 +43,7 @@ internal class CrashRunnable(
     private fun submitTimer() {
         val tracker = Tracker.instance
         crashHitsTimer.end()
+        crashHitsTimer.setField(Timer.FIELD_EXCLUDED, "20")
         crashHitsTimer.setPageName(Constants.CRASH_PAGE_NAME)
         crashHitsTimer.setFields(tracker?.globalFields?.toMap() ?: emptyMap())
         val timerRunnable = TimerRunnable(configuration, crashHitsTimer)

--- a/analytics/src/main/java/com/bluetriangle/analytics/CrashRunnable.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/CrashRunnable.kt
@@ -41,10 +41,9 @@ internal class CrashRunnable(
     }
 
     private fun submitTimer() {
-        val deviceName = Utils.deviceName
         val tracker = Tracker.instance
         crashHitsTimer.end()
-        crashHitsTimer.setPageName("Android Crash $deviceName")
+        crashHitsTimer.setPageName(Constants.CRASH_PAGE_NAME)
         crashHitsTimer.setFields(tracker?.globalFields?.toMap() ?: emptyMap())
         val timerRunnable = TimerRunnable(configuration, crashHitsTimer)
         timerRunnable.run()
@@ -58,11 +57,11 @@ internal class CrashRunnable(
             .appendQueryParameter(Timer.FIELD_NAVIGATION_START, crashHitsTimer.getField(Timer.FIELD_NST))
             .appendQueryParameter(
                 Timer.FIELD_PAGE_NAME,
-                crashHitsTimer.getField(Timer.FIELD_PAGE_NAME, "Android Crash $deviceName")
+                crashHitsTimer.getField(Timer.FIELD_PAGE_NAME, Constants.CRASH_PAGE_NAME)
             )
             .appendQueryParameter(
                 Timer.FIELD_TRAFFIC_SEGMENT_NAME,
-                crashHitsTimer.getField(Timer.FIELD_TRAFFIC_SEGMENT_NAME, "Android Crash")
+                crashHitsTimer.getField(Timer.FIELD_TRAFFIC_SEGMENT_NAME, Constants.CRASH_PAGE_NAME)
             )
             .appendQueryParameter(Timer.FIELD_NATIVE_OS, crashHitsTimer.getField(Timer.FIELD_NATIVE_OS, Constants.OS))
             .appendQueryParameter(

--- a/analytics/src/main/java/com/bluetriangle/analytics/Timer.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Timer.kt
@@ -55,6 +55,7 @@ class Timer : Parcelable {
         const val FIELD_BROWSER_VERSION = "browserVersion"
         const val FIELD_SDK_VERSION = "btV"
         const val FIELD_WCDTT = "WCDtt"
+        const val FIELD_EXCLUDED = "excluded"
 
         /**
          * A map of fields and their associated default values


### PR DESCRIPTION
Sets crash timer page name to `Android Crash` and adds `excluded` field set to `20`.

Below is an example crash data:

```
           BlueTriangle  D  Timer Data: {
                         D    "bvzn": "",
                         D    "EUOS": "Android",
                         D    "os": "Android",
                         D    "eventType": "9",
                         D    "navigationType": "9",
                         D    "RV": "0",
                         D    "CV4": "0",
                         D    "wcd": "0",
                         D    "DCTR": "Default",
                         D    "AB": "Default",
                         D    "bv": "0",
                         D    "top": "0",
                         D    "campaign": "",
                         D    "CmpN": "",
                         D    "CmpM": "",
                         D    "CmpS": "",
                         D    "RefURL": "",
                         D    "thisURL": "",
                         D    "cartValue": "0",
                         D    "orderTND": "0",
                         D    "ONumBr": "",
                         D    "pageValue": "0",
                         D    "pageType": "",
                         D    "unloadEventStart": "1663005196422",
                         D    "nst": "1663005196422",
                         D    "pgTm": "7",
                         D    "excluded": "20",
                         D    "pageName": "Android Crash",
                         D    "gID": "4845759496677589763",
                         D    "btV": "2.6.8",
                         D    "browser": "Native App",
                         D    "browserVersion": "Native App-1.0-Android 10",
                         D    "siteID": "mobelux3271241z",
                         D    "device": "Mobile",
                         D    "txnName": "Demo Traffic Segment",
                         D    "sID": "6814049920084981523"
                         D  }
                         D  BTT Timer: Android Crash submitted successfully
                         D  Crash Report URL: https://d.btttag.com/err.rcv?siteID=mobelux3271241z&nStart=1663005196422&pageName=Android%20Crash&txnName=Demo%20Traffic%20Segment&os=Android&device=Mobile&browser=Native%20A
                            pp&browserVersion=Native%20App-1.0-Android%2010&sessionID=6814049920084981523&pgTm=7&pageType=KYOCERA%20E6910&AB=Default&DCTR=Default&CmpN=&CmpM=Android&CmpS=Crash
                         D  Crash Report Data: [
                         D    {
                         D      "msg": "java.lang.ArithmeticException: divide by zero~~\tat com.bluetriangle.analytics.Tracker.raiseTestException(Tracker.kt:382)~~\tat com.bluetriangle.android.demo.MainActivity.crashButt
                            onClicked(MainActivity.java:120)~~\tat com.bluetriangle.android.demo.MainActivity_ViewBinding$4.doClick(MainActivity_ViewBinding.java:76)~~\tat butterknife.internal.DebouncingOnClickListener.o
                            nClick(DebouncingOnClickListener.java:26)~~\tat android.view.View.performClick(View.java:7154)~~\tat android.view.View.performClickInternal(View.java:7131)~~\tat android.view.View.access$3500(
                            View.java:801)~~\tat android.view.View$PerformClick.run(View.java:27369)~~\tat android.os.Handler.handleCallback(Handler.java:883)~~\tat android.os.Handler.dispatchMessage(Handler.java:100)~~\
                            tat android.os.Looper.loop(Looper.java:214)~~\tat android.app.ActivityThread.main(ActivityThread.java:7529)~~\tat java.lang.reflect.Method.invoke(Native Method)~~\tat com.android.internal.os.R
                            untimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)~~\tat com.android.internal.os.ZygoteInit.main(ZygoteInit.java:935)~~",
                         D      "eTp": "NativeAppCrash",
                         D      "eCnt": "1",
                         D      "url": "Blue Triangle Android Demo Android 10",
                         D      "line": "1",
                         D      "col": "1",
                         D      "time": "1663005196417"
                         D    }
                         D  ]


```