### PR TITLE
Relative start/end times for captured requests

### DIFF
--- a/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
@@ -152,6 +152,7 @@ class Tracker private constructor(context: Context, configuration: BlueTriangleC
     fun submitCapturedRequest(capturedRequest: CapturedRequest?) {
         if (configuration.shouldSampleNetwork) {
             getMostRecentTimer()?.let { timer ->
+                capturedRequest?.setNavigationStart(timer.start)
                 if (capturedRequests.containsKey(timer.start)) {
                     capturedRequests[timer.start]!!.add(capturedRequest!!)
                 } else {

--- a/analytics/src/main/java/com/bluetriangle/analytics/networkcapture/CapturedRequest.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/networkcapture/CapturedRequest.kt
@@ -86,7 +86,7 @@ class CapturedRequest {
                 FIELD_DECODED_BODY_SIZE to decodedBodySize.toString(),
                 FIELD_ENCODED_BODY_SIZE to encodedBodySize.toString(),
 
-            )
+                )
         }
 
     /**
@@ -98,11 +98,23 @@ class CapturedRequest {
         }
     }
 
+    /**
+     * stop the request timer if not already stopped
+     */
     fun stop() {
         if (startTime > 0 && endTime == 0L) {
             endTime = System.currentTimeMillis()
             duration = endTime - startTime
         }
+    }
+
+    /**
+     * Give the captured request the navigation start time so it can report request start and end relative to the
+     * navigation start time
+     */
+    fun setNavigationStart(navigationStart: Long) {
+        startTime -= navigationStart
+        endTime -= navigationStart
     }
 
     /**


### PR DESCRIPTION
Captured request's start `sT` and end times `rE` should be relative to the associated timer's navigation start.

``` json
{
        "e": "resource",
        "dmn": "httpbin.org",
        "h": "httpbin.org",
        "URL": "https:\/\/httpbin.org\/post",
        "f": "post",
        "sT": "54",
        "rE": "134",
        "d": "80",
        "i": "json",
        "dz": "0",
        "ez": "441"
      }
```