### PR TITLE
Initialize Tracker with Configuration

### DIFF
--- a/analytics/src/main/java/com/bluetriangle/analytics/MetadataReader.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/MetadataReader.kt
@@ -20,11 +20,12 @@ internal object MetadataReader {
         try {
             val metadata = getMetadata(context)
             if (metadata != null) {
-                val siteId = readString(metadata, SITE_ID, null)
+                val siteId = readString(metadata, SITE_ID, configuration.siteId)
                 if (TextUtils.isEmpty(siteId)) {
                     configuration.logger?.error("No site ID")
+                } else {
+                    configuration.siteId = siteId
                 }
-                configuration.siteId = siteId
                 configuration.isDebug = readBool(metadata, DEBUG, configuration.isDebug)
                 configuration.debugLevel = readInt(metadata, DEBUG_LEVEL, configuration.debugLevel)
                 configuration.maxCacheItems = readInt(metadata, MAX_CACHE_ITEMS, configuration.maxCacheItems)

--- a/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
@@ -407,11 +407,11 @@ class Tracker private constructor(context: Context, configuration: BlueTriangleC
          * Initialize the tracker with default tracker URL and Site ID from string resources.
          *
          * @param context application context
-         * @return the initialized tracker
+         * @return the initialized tracker or null if no site ID
          */
         @JvmStatic
         fun init(context: Context): Tracker? {
-            return init(context, null, null)
+            return init(context, BlueTriangleConfiguration())
         }
 
         /**
@@ -419,44 +419,69 @@ class Tracker private constructor(context: Context, configuration: BlueTriangleC
          *
          * @param context application context
          * @param siteId  Site ID to send with all timers
-         * @return the initialized tracker
+         * @return the initialized tracker or null if no site ID
          */
         @JvmStatic
         fun init(context: Context, siteId: String?): Tracker? {
-            return init(context, siteId, null)
+            val configuration = BlueTriangleConfiguration()
+            configuration.siteId = siteId
+            return init(context, configuration)
         }
 
         /**
-         * Initialize the tracker with given tracker URL and site ID
+         * Initialize the tracker with default tracker URL and given Site ID
          *
-         * @param context    application context
-         * @param siteId     Site ID to send with all timers
+         * @param context application context
+         * @param siteId  Site ID to send with all timers
          * @param trackerUrl the URL to submit timer data
-         * @return the initialized tracker
+         * @return the initialized tracker or null if no site ID
+         */
+        @JvmStatic
+        fun init(context: Context, siteId: String?, trackerUrl: String?): Tracker? {
+            val configuration = BlueTriangleConfiguration()
+            configuration.siteId = siteId
+            if (!trackerUrl.isNullOrBlank()) {
+                configuration.trackerUrl = trackerUrl
+            }
+            return init(context, configuration)
+        }
+
+        /**
+         * Initialize the tracker with the given configuration
+         *
+         * @param context application context
+         * @param configuration Blue Triangle Configuration
+         * @return the initialized tracker or null if no site ID
          */
         @JvmStatic
         @Synchronized
-        fun init(context: Context, siteId: String?, trackerUrl: String?): Tracker? {
+        fun init(context: Context, configuration: BlueTriangleConfiguration): Tracker? {
             if (instance != null) {
                 return instance
             }
-            val configuration = BlueTriangleConfiguration()
-            MetadataReader.applyMetadata(context, configuration)
-            configuration.applicationName = Utils.getAppNameAndOs(context)
-            configuration.userAgent = Utils.buildUserAgent(context)
-            val cacheDir = File(context.cacheDir, "bta")
-            if (!cacheDir.exists()) {
-                if (!cacheDir.mkdir()) {
-                    configuration.logger?.error("Error creating cache directory: ${cacheDir.absolutePath}")
-                }
-            }
-            configuration.cacheDirectory = cacheDir.absolutePath
-            if (!siteId.isNullOrBlank()) {
-                configuration.siteId = siteId
+
+            if (configuration.isDebug) {
+                configuration.logger = AndroidLogger(configuration.debugLevel)
             }
 
-            if (!trackerUrl.isNullOrBlank()) {
-                configuration.trackerUrl = trackerUrl
+            MetadataReader.applyMetadata(context, configuration)
+
+            if (configuration.applicationName.isNullOrBlank()) {
+                configuration.applicationName = Utils.getAppNameAndOs(context)
+            }
+
+            if (configuration.userAgent.isNullOrBlank()) {
+                configuration.userAgent = Utils.buildUserAgent(context)
+            }
+
+            if (configuration.cacheDirectory.isNullOrBlank()) {
+                val cacheDir = File(context.cacheDir, "bta")
+                if (!cacheDir.exists()) {
+                    if (!cacheDir.mkdir()) {
+                        configuration.logger?.error("Error creating cache directory: ${cacheDir.absolutePath}")
+                    }
+                }
+                configuration.cacheDirectory = cacheDir.absolutePath
             }
 
             // if site id is still not configured, try legacy resource string method
@@ -466,9 +491,13 @@ class Tracker private constructor(context: Context, configuration: BlueTriangleC
                     configuration.siteId = resourceSiteID
                 }
             }
-            if (configuration.isDebug) {
-                configuration.logger = AndroidLogger(configuration.debugLevel)
+
+            // if still no site ID, log error
+            if (configuration.siteId.isNullOrBlank()) {
+                configuration.logger?.error("Site ID is required.")
+                return null
             }
+
             instance = Tracker(context, configuration)
             return instance
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,11 +22,11 @@
         </activity>
         <activity android:name=".NextActivity"></activity>
 
-        <meta-data android:name="com.blue-triangle.site-id" android:value="mobelux3271241z" />
-        <meta-data android:name="com.blue-triangle.debug" android:value="true" />
-        <meta-data android:name="com.blue-triangle.performance-monitor.enable" android:value="true" />
-        <meta-data android:name="com.blue-triangle.track-crashes.enable" android:value="true" />
-        <meta-data android:name="com.blue-triangle.sample-rate.network" android:value="1.0" />
+<!--        <meta-data android:name="com.blue-triangle.site-id" android:value="mobelux3271241z" />-->
+<!--        <meta-data android:name="com.blue-triangle.debug" android:value="true" />-->
+<!--        <meta-data android:name="com.blue-triangle.performance-monitor.enable" android:value="true" />-->
+<!--        <meta-data android:name="com.blue-triangle.track-crashes.enable" android:value="true" />-->
+<!--        <meta-data android:name="com.blue-triangle.sample-rate.network" android:value="1.0" />-->
 
     </application>
 

--- a/app/src/main/java/com/bluetriangle/android/demo/DemoApplication.java
+++ b/app/src/main/java/com/bluetriangle/android/demo/DemoApplication.java
@@ -1,6 +1,8 @@
 package com.bluetriangle.android.demo;
 
 import android.app.Application;
+
+import com.bluetriangle.analytics.BlueTriangleConfiguration;
 import com.bluetriangle.analytics.Tracker;
 
 public class DemoApplication extends Application {
@@ -10,15 +12,13 @@ public class DemoApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        // d.btttag.com => 107.22.227.162
-        //"http://107.22.227.162/btt.gif"
-        //https://d.btttag.com/analytics.rcv
-        //sdkdemo26621z
-        //bluetriangledemo500z
-        tracker = Tracker.init(getApplicationContext());
-        tracker.setSessionTrafficSegmentName("Demo Traffic Segment");
-        //tracker.raiseTestException();
 
+        final BlueTriangleConfiguration configuration = new BlueTriangleConfiguration();
+        configuration.setTrackCrashesEnabled(true);
+        configuration.setSiteId("mobelux3271241z");
+        tracker = Tracker.init(getApplicationContext(), configuration);
+
+        tracker.setSessionTrafficSegmentName("Demo Traffic Segment");
     }
 }
 

--- a/app/src/main/java/com/bluetriangle/android/demo/DemoApplication.java
+++ b/app/src/main/java/com/bluetriangle/android/demo/DemoApplication.java
@@ -16,6 +16,9 @@ public class DemoApplication extends Application {
         final BlueTriangleConfiguration configuration = new BlueTriangleConfiguration();
         configuration.setTrackCrashesEnabled(true);
         configuration.setSiteId("mobelux3271241z");
+        configuration.setDebug(true);
+        configuration.setNetworkSampleRate(1.0);
+        configuration.setPerformanceMonitorEnabled(true);
         tracker = Tracker.init(getApplicationContext(), configuration);
 
         tracker.setSessionTrafficSegmentName("Demo Traffic Segment");

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
     <string name="app_name">Blue Triangle Android Demo</string>
-    <string name="btt_site_id" translatable="false">testsite1</string>
 </resources>


### PR DESCRIPTION
Allows for end-user to initialize the tracker with a BlueTriangleConfigration object instead of relying on metadata configuration for configuration options that need to be set during initialization phase of the tracker.