### PR TITLE
Feature/fresh install and force restart tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-# Blue Triangle 2.19.4 Latest, Mar 23 2026
+# Blue Triangle 2.19.5 Latest, May 22 2026
+### New Features and Bug Fixes
+- App installs tracking: BlueTriangle can now track new app installs.
+- App Force Restart Tracking: If the user force restarts the app, kills it, and restarts immediately, BlueTriangle tracks it as Force Restart. User has a tendency to force restart the app if something on the current screen is not working. BlueTriangle can now track this as an error.
+
+### Bug Fixes and Improvements
+- Disabling user tap interspersion for groups will also disable it in breadcrumbs.
+
+# Blue Triangle 2.19.4, Mar 23 2026
 ### New Improvements
 - Added breadcrumbs for ANRs, crashes, and memory warnings
 - Added configKey to Launch time beacon

--- a/README.md
+++ b/README.md
@@ -711,6 +711,16 @@ fun testCrashTracking() {
 }
 ```
 
+### App Install
+
+The BlueTriangle SDK automatically tracks new App Installs. Install event will be reported on next app launch after install. Hence, the time of the event may not necessarily be time of install it will be the time when user first time launched app after installation. If user launches app after 72 hours(3 days) post installation, BlueTriangle ignores this installation reporting.
+
+### Force Restart
+
+User has a tendency to force-kill the app and launch it again if something is not working on a screen. BlueTriangle treats this as bad performance and tracks this as "ForceRestart" error. BlueTriangle tracks sequence of evens including app being killed by user and then launched again in 10 seconds. We show this error in error explorer with type "ForceRestart". BlueTriangle tries to collect name of Activity or Fragment visible when user forces restarts the can be seen under page name. This feature is supported from Android 11 (API Level 30) and above.
+
+BlueTriangle tracks user-terminated app, and user launched app again by listening to lifecycle event Activity.onPause and AppLifecycleEvent.AppLifecycleCreated. These two sequence of notifications in a short time period and ApplicationExitInfo.reason is ApplicationExitInfo.REASON_USER_REQUESTED make "Force Restart" error.
+
 ### Microsoft Clarity Integration
 
 Blue Triangle offers session playback via Microsoft Clarity integration. For help with this process, please reach out to your Blue Triangle representative.

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'kotlin-parcelize'
 }
 
-version = "2.19.4"
+version = "2.19.5"
 
 android {
     namespace 'com.bluetriangle.analytics'
@@ -91,7 +91,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.github.blue-triangle-tech'
                 artifactId = 'btt-android-sdk'
-                version = "2.19.4"
+                version = "2.19.5"
             }
         }
     }

--- a/analytics/src/main/java/com/bluetriangle/analytics/BlueTriangleConfiguration.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/BlueTriangleConfiguration.kt
@@ -183,6 +183,21 @@ class BlueTriangleConfiguration {
     internal val shouldDetectTap: Boolean
         get() = isGroupingEnabled && isGroupingTapDetectionEnabled
 
+    /**
+     * Enable or disable App Install sending reports to the server.
+     */
+    var isAppInstallEnabled: Boolean = true
+
+    /**
+     * Enable or disable App Force Restart sending reports to the server.
+     */
+    var isForceRestartEnable: Boolean = true
+
+    /**
+     * Enable or disable App Force Restart sending reports to the server.
+     */
+    var forceRestartDuration: Double = 10.0
+
     companion object {
         const val DEFAULT_TRACKER_URL = "https://d.btttag.com/analytics.rcv"
         const val DEFAULT_ERROR_REPORTING_URL = "https://d.btttag.com/err.rcv"
@@ -223,7 +238,10 @@ class BlueTriangleConfiguration {
             cacheMemoryLimit : $cacheMemoryLimit
             isTrackNetworkStateEnabled : $isTrackNetworkStateEnabled,
             isGroupingEnabled : $isGroupingEnabled,
-            groupingIdleTime : $groupingIdleTime
+            groupingIdleTime : $groupingIdleTime,
+            isAppInstallEnabled : $isAppInstallEnabled,
+            isForceRestartEnable : $isForceRestartEnable,
+            forceRestartDuration : $forceRestartDuration
         }
         """.trimIndent()
     }

--- a/analytics/src/main/java/com/bluetriangle/analytics/Constants.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Constants.kt
@@ -40,6 +40,9 @@ object Constants {
     internal const val DEFAULT_ENABLE_MEMORY_WARNING = true
     internal const val DEFAULT_ENABLE_LAUNCH_TIME = true
     internal const val DEFAULT_ENABLE_WEB_VIEW_STITCHING = true
+    internal const val DEFAULT_ENABLE_APP_INSTALL = true
+    internal const val DEFAULT_ENABLE_FORCE_RESTART = true
+    internal const val DEFAULT_FORCE_RESTART_DURATION = 10.0
     internal const val DEFAULT_GROUPED_VIEW_SAMPLE_RATE = 0.05
 
     internal const val DEFAULT_CHECKOUT_TRACKING_ENABLED = false

--- a/analytics/src/main/java/com/bluetriangle/analytics/Constants.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Constants.kt
@@ -81,6 +81,7 @@ object Constants {
 
     internal const val DEFAULT_TRAFFIC_SEGMENT_NAME = "Main Segment"
     internal const val DEFAULT_CONTENT_GROUP_NAME = "Main Group"
+    internal const val INSTALL_TIME = "installTime"
     internal const val MAX_FIELD_CHAR_LENGTH: Int = 512
 
     internal const val DEFAULT_ENABLE_BREADCRUMBS = true

--- a/analytics/src/main/java/com/bluetriangle/analytics/Constants.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Constants.kt
@@ -52,6 +52,7 @@ object Constants {
 
     internal const val SDK_VERSION = "sdkVersion"
     internal const val APP_VERSION = "appVersion"
+    internal const val APP_LAST_FOREGROUND_TIME = "appLastForegroundTime"
 
     internal const val BREADCRUMBS = "breadcrumbs"
     internal const val NUMBER_OF_CPU_CORES = "numberOfCPUCores"

--- a/analytics/src/main/java/com/bluetriangle/analytics/MetadataReader.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/MetadataReader.kt
@@ -22,6 +22,9 @@ internal object MetadataReader {
     private const val CACHE_MEMORY_LIMIT = "com.blue-triangle.cache.memory-limit"
     private const val CACHE_EXPIRY = "com.blue-triangle.cache.expiry"
     private const val TRACK_NETWORK_STATE_ENABLE = "com.blue-triangle.track-network-state.enable"
+    private const val APP_INSTALL_ENABLE = "com.blue-triangle.app-install.enable"
+    private const val FORCE_RESTART_ENABLE = "com.blue-triangle.force-restart.enable"
+    private const val FORCE_RESTART_DURATION_SECONDS = "com.blue-triangle.force-restart.duration-sec"
 
     fun applyMetadata(context: Context, configuration: BlueTriangleConfiguration) {
         try {
@@ -73,6 +76,12 @@ internal object MetadataReader {
                 )
                 configuration.isTrackNetworkStateEnabled =
                     readBool(metadata, TRACK_NETWORK_STATE_ENABLE, configuration.isTrackNetworkStateEnabled)
+                configuration.isAppInstallEnabled =
+                    readBool(metadata, APP_INSTALL_ENABLE, configuration.isAppInstallEnabled)
+                configuration.isForceRestartEnable =
+                    readBool(metadata, FORCE_RESTART_ENABLE, configuration.isForceRestartEnable)
+                configuration.forceRestartDuration = readDouble(
+                    metadata, FORCE_RESTART_DURATION_SECONDS, configuration.forceRestartDuration)
             }
         } catch (e: Throwable) {
             configuration.logger?.error(e, "Error reading metadata configuration")

--- a/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
@@ -25,6 +25,7 @@ import com.bluetriangle.analytics.Timer.Companion.FIELD_SESSION_ID
 import com.bluetriangle.analytics.Timer.Companion.FIELD_TRAFFIC_SEGMENT_NAME
 import com.bluetriangle.analytics.anrwatchdog.ANRReporter
 import com.bluetriangle.analytics.anrwatchdog.AnrManager
+import com.bluetriangle.analytics.applaunch.AppLaunchReporter
 import com.bluetriangle.analytics.breadcrumbs.BreadcrumbsManager
 import com.bluetriangle.analytics.breadcrumbs.config.BreadcrumbsConfig
 import com.bluetriangle.analytics.checkout.config.CheckoutConfig
@@ -139,6 +140,10 @@ class Tracker private constructor(
 
     private val claritySessionConnector:ClaritySessionConnector
     internal val appVersion: String
+    internal var firstInstallTime: Long? = null
+        @Synchronized set
+
+    internal var appLaunchReporter: AppLaunchReporter
 
     private var launchReporter: LaunchReporter? = null
 
@@ -159,6 +164,7 @@ class Tracker private constructor(
         this.configuration = configuration
         this.deviceInfoProvider = DeviceInfoProvider
         this.anrReporter = ANRReporter(deviceInfoProvider)
+        this.appLaunchReporter = AppLaunchReporter()
         this.memoryWarningReporter = MemoryWarningReporter(deviceInfoProvider)
         this.globalPropertiesStore = GlobalPropertiesStore(application.applicationContext)
 
@@ -256,7 +262,16 @@ class Tracker private constructor(
         sharedPreferences?.let {
             val lastAppVersion = it.getString(APP_VERSION, null)
             if(lastAppVersion == null) {
-                SDKEventHub.instance.onAppInstall(appVersion)
+                context.get()?.let { ct ->
+                    val installTime: Long =
+                        ct.packageManager.getPackageInfo(ct.packageName, 0).firstInstallTime
+                    val updateTime: Long =
+                        ct.packageManager.getPackageInfo(ct.packageName, 0).lastUpdateTime
+                    if (installTime == updateTime) {
+                        firstInstallTime = installTime
+                        SDKEventHub.instance.onAppInstall(appVersion)
+                    }
+                }
             } else if(lastAppVersion != appVersion) {
                 SDKEventHub.instance.onAppUpdate(lastAppVersion, appVersion)
             }
@@ -1425,6 +1440,13 @@ class Tracker private constructor(
                             instance?.disable()
                             deInitializeSessionManager()
                             instance = null
+                        }
+                    }
+
+                    instance?.firstInstallTime?.let { installTime ->
+                        if (it?.enableAppInstall == true) {
+                            instance?.firstInstallTime = null
+                            instance?.appLaunchReporter?.reportAppInstall(installTime)
                         }
                     }
                 }

--- a/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
@@ -1314,7 +1314,10 @@ class Tracker private constructor(
                 enableWebViewStitching = configuration.isWebViewStitchingEnabled,
                 checkoutConfig = CheckoutConfig.DEFAULT,
                 breadcrumbsConfig = BreadcrumbsConfig.DEFAULT,
-                configKey = DEFAULT_CONFIG_KEY
+                configKey = DEFAULT_CONFIG_KEY,
+                enableAppInstall = configuration.isAppInstallEnabled,
+                enableForceRestart = configuration.isForceRestartEnable,
+                forceRestartDuration = configuration.forceRestartDuration
             )
 
             initializeConfigurationUpdater(application, configuration, defaultConfig)
@@ -1442,6 +1445,9 @@ class Tracker private constructor(
             isLaunchTimeEnabled = sessionData.enableLaunchTime
             isWebViewStitchingEnabled = sessionData.enableWebViewStitching
             isScreenTrackingEnabled = sessionData.enableScreenTracking
+            isAppInstallEnabled = sessionData.enableAppInstall
+            isForceRestartEnable = sessionData.enableForceRestart
+            forceRestartDuration = sessionData.forceRestartDuration
         }
 
         private lateinit var configurationRepository: IBTTConfigurationRepository

--- a/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
@@ -240,7 +240,7 @@ class Tracker private constructor(
     }
 
     private fun enableBreadcrumbs(breadcrumbsConfig: BreadcrumbsConfig, shouldDetectTap: Boolean) {
-        breadcrumbsManager = BreadcrumbsManager(breadcrumbsConfig, shouldDetectTap)
+        breadcrumbsManager = BreadcrumbsManager(breadcrumbsConfig, shouldDetectTap, context)
         breadcrumbsManager?.install()
     }
 
@@ -751,6 +751,11 @@ class Tracker private constructor(
         }
     }
 
+    fun onScreenPause() {
+        // Save breadcrumbs on screen pause
+        breadcrumbsManager?.dump()
+    }
+
     /**
      * Set a global field to be applied to all trackers
      *
@@ -1193,7 +1198,7 @@ class Tracker private constructor(
     }
 
     companion object {
-        private const val SHARED_PREFERENCES_NAME = "BTT_SHARED_PREFERENCES"
+        internal const val SHARED_PREFERENCES_NAME = "BTT_SHARED_PREFERENCES"
 
         /**
          * String resource name for the site ID

--- a/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
@@ -232,15 +232,15 @@ class Tracker private constructor(
             LifecycleRegistry.install(it)
         }
         if(sessionData.breadcrumbsConfig.isEnabled) {
-            enableBreadcrumbs(sessionData.breadcrumbsConfig)
+            enableBreadcrumbs(sessionData.breadcrumbsConfig, configuration.shouldDetectTap)
         }
 
         checkAppVersion()
         configuration.logger?.debug("SDK is enabled")
     }
 
-    private fun enableBreadcrumbs(breadcrumbsConfig: BreadcrumbsConfig) {
-        breadcrumbsManager = BreadcrumbsManager(breadcrumbsConfig)
+    private fun enableBreadcrumbs(breadcrumbsConfig: BreadcrumbsConfig, shouldDetectTap: Boolean) {
+        breadcrumbsManager = BreadcrumbsManager(breadcrumbsConfig, shouldDetectTap)
         breadcrumbsManager?.install()
     }
 
@@ -938,15 +938,15 @@ class Tracker private constructor(
         if(sessionData.breadcrumbsConfig.isEnabled != isBreadcrumbsEnabled) {
             changes.append("\nenableBreadcrumbs: $isBreadcrumbsEnabled -> ${sessionData.breadcrumbsConfig.isEnabled}")
             if(sessionData.breadcrumbsConfig.isEnabled) {
-                enableBreadcrumbs(sessionData.breadcrumbsConfig)
+                enableBreadcrumbs(sessionData.breadcrumbsConfig, configuration.shouldDetectTap)
             } else {
                 disableBreadcrumbs()
             }
         }
 
-        if(sessionData.breadcrumbsConfig.ignoredFeatures != breadcrumbsManager?.config?.ignoredFeatures) {
+        if(sessionData.breadcrumbsConfig.ignoredFeatures != breadcrumbsManager?.config?.ignoredFeatures || configuration.isGroupingTapDetectionEnabled != sessionData.enableGroupingTapDetection) {
             changes.append("\nignoreBreadcrumbs: ${breadcrumbsManager?.config?.ignoredFeatures} -> ${sessionData.breadcrumbsConfig.ignoredFeatures}")
-            breadcrumbsManager?.updateConfig(sessionData.breadcrumbsConfig)
+            breadcrumbsManager?.updateConfig(sessionData.breadcrumbsConfig, configuration.shouldDetectTap)
         }
         val changesString = changes.toString()
         if(changesString.isNotEmpty()) {

--- a/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
@@ -19,7 +19,10 @@ import com.bluetriangle.analytics.Constants.APP_VERSION
 import com.bluetriangle.analytics.Constants.DEFAULT_CONFIG_KEY
 import com.bluetriangle.analytics.Constants.MAX_FIELD_CHAR_LENGTH
 import com.bluetriangle.analytics.Constants.UNKNOWN
+import com.bluetriangle.analytics.Timer.Companion.FIELD_CONTENT_GROUP_NAME
+import com.bluetriangle.analytics.Timer.Companion.FIELD_PAGE_NAME
 import com.bluetriangle.analytics.Timer.Companion.FIELD_SESSION_ID
+import com.bluetriangle.analytics.Timer.Companion.FIELD_TRAFFIC_SEGMENT_NAME
 import com.bluetriangle.analytics.anrwatchdog.ANRReporter
 import com.bluetriangle.analytics.anrwatchdog.AnrManager
 import com.bluetriangle.analytics.breadcrumbs.BreadcrumbsManager
@@ -751,9 +754,26 @@ class Tracker private constructor(
         }
     }
 
-    fun onScreenPause() {
+    fun onScreenPause(timer: Timer?) {
         // Save breadcrumbs on screen pause
         breadcrumbsManager?.dump()
+
+        val context = context.get() ?: return
+        val prefs = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+        // Save current time as last foreground time
+        prefs?.edit {
+            putLong(Constants.APP_LAST_FOREGROUND_TIME, System.currentTimeMillis())
+        }
+
+        // Save pageName/PageType/txnName of most recent timer
+        timer?.let { timer ->
+            prefs?.edit {
+                putString(FIELD_PAGE_NAME, timer.getField(FIELD_PAGE_NAME))
+                putString(FIELD_CONTENT_GROUP_NAME, timer.getField(FIELD_CONTENT_GROUP_NAME))
+                putString(FIELD_TRAFFIC_SEGMENT_NAME, timer.getField(FIELD_TRAFFIC_SEGMENT_NAME))
+            }
+        }
     }
 
     /**

--- a/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/Tracker.kt
@@ -164,7 +164,7 @@ class Tracker private constructor(
         this.configuration = configuration
         this.deviceInfoProvider = DeviceInfoProvider
         this.anrReporter = ANRReporter(deviceInfoProvider)
-        this.appLaunchReporter = AppLaunchReporter()
+        this.appLaunchReporter = AppLaunchReporter(configuration.logger, application.applicationContext, deviceInfoProvider, configuration.forceRestartDuration)
         this.memoryWarningReporter = MemoryWarningReporter(deviceInfoProvider)
         this.globalPropertiesStore = GlobalPropertiesStore(application.applicationContext)
 
@@ -244,6 +244,11 @@ class Tracker private constructor(
             enableBreadcrumbs(sessionData.breadcrumbsConfig, configuration.shouldDetectTap)
         }
 
+        if (configuration.isForceRestartEnable) {
+            appLaunchReporter.setForceRestartDuration(sessionData.forceRestartDuration)
+            startAppLaunchReporter()
+        }
+
         checkAppVersion()
         configuration.logger?.debug("SDK is enabled")
     }
@@ -297,6 +302,7 @@ class Tracker private constructor(
         disableLaunchMonitor()
         LifecycleRegistry.uninstall()
         disableBreadcrumbs()
+        stopAppLaunchReporter()
         configuration.logger?.debug("SDK is disabled.")
     }
 
@@ -308,6 +314,14 @@ class Tracker private constructor(
     private fun stopPerformanceMonitoring() {
         performanceMonitor?.stopRunning()
         performanceMonitor = null
+    }
+
+    private fun startAppLaunchReporter() {
+        appLaunchReporter.start()
+    }
+
+    private fun stopAppLaunchReporter() {
+        appLaunchReporter.stop()
     }
 
     fun trackCrashes() {
@@ -951,6 +965,22 @@ class Tracker private constructor(
             }
         }
 
+        if (configuration.forceRestartDuration != sessionData.forceRestartDuration) {
+            changes.append("\nforceRestartDuration: ${configuration.forceRestartDuration} -> ${sessionData.forceRestartDuration}")
+            configuration.forceRestartDuration = sessionData.forceRestartDuration
+            appLaunchReporter.setForceRestartDuration(sessionData.forceRestartDuration)
+        }
+
+        if (configuration.isForceRestartEnable != sessionData.enableForceRestart) {
+            changes.append("\nenableForceRestart: ${configuration.isForceRestartEnable} -> ${sessionData.enableForceRestart}")
+            configuration.isForceRestartEnable = sessionData.enableForceRestart
+            if (configuration.isForceRestartEnable) {
+                startAppLaunchReporter()
+            } else {
+                stopAppLaunchReporter()
+            }
+        }
+
         if(configuration.isWebViewStitchingEnabled != sessionData.enableWebViewStitching) {
             changes.append("\nenableWebViewStitching: ${configuration.isWebViewStitchingEnabled} -> ${sessionData.enableWebViewStitching}")
             configuration.isWebViewStitchingEnabled = sessionData.enableWebViewStitching
@@ -1217,6 +1247,7 @@ class Tracker private constructor(
         NativeAppCrash(BTTEvent.Crash),
         ANRWarning(BTTEvent.ANRWarning),
         MemoryWarning(BTTEvent.MemoryWarning),
+        ForceRestart(BTTEvent.ForceRestart),
         BTTConfigUpdateError;
 
         val errorName: String

--- a/analytics/src/main/java/com/bluetriangle/analytics/applaunch/AppLaunchReporter.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/applaunch/AppLaunchReporter.kt
@@ -1,0 +1,45 @@
+package com.bluetriangle.analytics.applaunch
+
+import com.bluetriangle.analytics.Constants
+import com.bluetriangle.analytics.Timer
+import com.bluetriangle.analytics.Tracker
+import com.bluetriangle.analytics.event.BTTEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+internal class AppLaunchReporter {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private var appInstallReportJob: Job? = null
+
+    fun reportAppInstall(installTime: Long) {
+        appInstallReportJob?.cancel()
+
+        appInstallReportJob = scope.launch {
+            while (Tracker.instance == null) delay(5)
+
+            Timer().apply {
+                startWithoutPerformanceMonitor()
+                setPageName(BTTEvent.AppInstall.defaultPageName)
+                setContentGroupName(BTTEvent.AppInstall.defaultPageName)
+                setTrafficSegmentName(BTTEvent.AppInstall.defaultPageName)
+                setTimeOnPage(Constants.TIMER_MIN_PGTM)
+                pageTimeCalculator = {
+                    Constants.TIMER_MIN_PGTM
+                }
+                generateNativeAppProperties()
+                nativeAppProperties.loadTime = Constants.TIMER_MIN_PGTM
+                nativeAppProperties.event = BTTEvent.AppInstall
+                nativeAppProperties.installTime = installTime
+
+                submit()
+
+                appInstallReportJob = null
+            }
+        }
+    }
+}

--- a/analytics/src/main/java/com/bluetriangle/analytics/applaunch/AppLaunchReporter.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/applaunch/AppLaunchReporter.kt
@@ -1,20 +1,45 @@
 package com.bluetriangle.analytics.applaunch
 
+import android.content.Context
 import com.bluetriangle.analytics.Constants
+import com.bluetriangle.analytics.CrashRunnable
+import com.bluetriangle.analytics.Logger
 import com.bluetriangle.analytics.Timer
 import com.bluetriangle.analytics.Tracker
+import com.bluetriangle.analytics.deviceinfo.IDeviceInfoProvider
 import com.bluetriangle.analytics.event.BTTEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-internal class AppLaunchReporter {
+internal class AppLaunchReporter(
+    logger: Logger?, val context: Context, val deviceInfoProvider: IDeviceInfoProvider, forceRestartDuration: Double
+) {
+    private var forceRestartTracker: ForceRestartTracker? = null
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private var appInstallReportJob: Job? = null
+
+    init {
+        forceRestartTracker = ForceRestartTracker(logger, context, this, forceRestartDuration)
+    }
+
+    fun start() {
+        forceRestartTracker?.start()
+    }
+
+    fun stop() {
+        forceRestartTracker?.stop()
+        scope.cancel()
+    }
+
+    fun setForceRestartDuration(forceRestartDuration: Double) {
+        forceRestartTracker?.setForceRestartDuration(forceRestartDuration)
+    }
 
     fun reportAppInstall(installTime: Long) {
         appInstallReportJob?.cancel()
@@ -40,6 +65,50 @@ internal class AppLaunchReporter {
 
                 appInstallReportJob = null
             }
+        }
+    }
+
+    fun reportForceKill(pageName: String?, pageType: String?, txnName: String?) {
+        val configuration = Tracker.instance?.configuration!!
+
+        val timeStamp = System.currentTimeMillis().toString()
+        val mostRecentTimer = Tracker.instance?.getMostRecentTimer()
+
+        val timer = Timer().apply {
+            startWithoutPerformanceMonitor()
+            setPageName(pageName ?: mostRecentTimer?.getField(Timer.FIELD_PAGE_NAME) ?: "Unknown")
+            //setContentGroupName(BTTEvent.ForceRestart.defaultPageName)
+            setContentGroupName(
+                pageType ?: mostRecentTimer?.getField(Timer.FIELD_CONTENT_GROUP_NAME) ?: ""
+            )
+            setTrafficSegmentName(
+                txnName ?: mostRecentTimer?.getField(Timer.FIELD_TRAFFIC_SEGMENT_NAME) ?: ""
+            )
+            setTimeOnPage(Constants.TIMER_MIN_PGTM)
+            pageTimeCalculator = {
+                Constants.TIMER_MIN_PGTM
+            }
+            generateNativeAppProperties()
+            nativeAppProperties.loadTime = Constants.TIMER_MIN_PGTM
+            nativeAppProperties.event = BTTEvent.ForceRestart
+        }
+
+        try {
+            val thread = Thread(
+                CrashRunnable(
+                    configuration,
+                    "User force restarted app.",
+                    timeStamp,
+                    Tracker.BTErrorType.ForceRestart,
+                    timer,
+                    deviceInfoProvider = deviceInfoProvider,
+                    breadcrumbs = Tracker.instance?.breadcrumbsManager?.getCachedSnapshot()
+                )
+            )
+            thread.start()
+            thread.join()
+        } catch (interruptedException: InterruptedException) {
+            interruptedException.printStackTrace()
         }
     }
 }

--- a/analytics/src/main/java/com/bluetriangle/analytics/applaunch/ForceRestartTracker.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/applaunch/ForceRestartTracker.kt
@@ -1,0 +1,104 @@
+package com.bluetriangle.analytics.applaunch
+
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
+import android.content.Context
+import android.os.Build
+import com.bluetriangle.analytics.Constants
+import com.bluetriangle.analytics.Logger
+import com.bluetriangle.analytics.Timer.Companion.FIELD_CONTENT_GROUP_NAME
+import com.bluetriangle.analytics.Timer.Companion.FIELD_PAGE_NAME
+import com.bluetriangle.analytics.Timer.Companion.FIELD_TRAFFIC_SEGMENT_NAME
+import com.bluetriangle.analytics.Tracker
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+internal class ForceRestartTracker(
+    private val logger: Logger?, private val context: Context, private val reporter:AppLaunchReporter, forceRestartDuration: Double
+) {
+    private var _forceRestartDuration: Long = 10_000
+    private var appForceKillReportJob: Job? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    init {
+        _forceRestartDuration = (forceRestartDuration * 1000).toLong()
+    }
+
+    fun setForceRestartDuration(forceRestartDuration: Double) {
+        _forceRestartDuration = (forceRestartDuration * 1000).toLong()
+    }
+
+    fun start() {
+        val prefs =
+            context.getSharedPreferences(Tracker.SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+        val lastForegroundTime = prefs.getLong(Constants.APP_LAST_FOREGROUND_TIME, 0L)
+
+        checkAppPreviousExit(System.currentTimeMillis(), lastForegroundTime)
+    }
+
+    fun stop() {
+        scope.cancel()
+    }
+
+    private fun checkAppPreviousExit(currentTime: Long, lastForegroundTime: Long) {
+        if (lastForegroundTime == 0L) return
+
+        // If the app was restarted within 10 seconds, we assume it was died unexpectedly
+        val diedUnexpectedly = (currentTime - lastForegroundTime) < _forceRestartDuration
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val activityManager =
+                context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+
+            // Retrieve the most recent exit reason for this app
+            val exitList =
+                activityManager.getHistoricalProcessExitReasons(context.packageName, 0, 1)
+            if (exitList.isNotEmpty()) {
+                val lastExit = exitList[0]
+
+                val isUnexpectedReason = when (lastExit.reason) {
+                    ApplicationExitInfo.REASON_USER_REQUESTED -> true
+
+                    else -> false
+                }
+
+                if (diedUnexpectedly && isUnexpectedReason) {
+                    reportForceKill()
+
+                    logger?.debug(
+                        "ForceRestartTracker → App Unexpectedly Exit at ${lastExit.timestamp}, Status: ${lastExit.status}, Description: ${lastExit.description}"
+                    )
+                }
+            }
+        } else if (diedUnexpectedly) {
+            //reportForceKill()
+            logger?.debug(
+                "ForceRestartTracker → App Unexpectedly Exit - lastAliveTime=$lastForegroundTime"
+            )
+        }
+    }
+
+    private fun reportForceKill() {
+        val prefs =
+            context.getSharedPreferences(Tracker.SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+        val pageName = prefs.getString(FIELD_PAGE_NAME, "")
+        val pageType = prefs.getString(FIELD_CONTENT_GROUP_NAME, "")
+        val txnName = prefs.getString(FIELD_TRAFFIC_SEGMENT_NAME, "")
+
+        appForceKillReportJob?.cancel()
+
+        appForceKillReportJob = scope.launch {
+            while (Tracker.instance == null) delay(5)
+
+            reporter.reportForceKill(pageName, pageType, txnName)
+            appForceKillReportJob?.cancel()
+        }
+    }
+}

--- a/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbEvent.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbEvent.kt
@@ -17,6 +17,28 @@ internal sealed class BreadcrumbEvent(
         data.writeTo(this)
     }
 
+    companion object {
+        fun fromJson(json: JSONObject): BreadcrumbEvent? {
+            val type = json.getString("type")
+            val timestamp = json.getLong("timestamp")
+            return when (type) {
+                "ui.lifecycle" -> UiLifecycle(UiLifecycle.UiLifecycleData.fromJson(json))
+                "system.event" -> SystemEvent(SystemEvent.SystemEventData.fromJson(json))
+                "app.lifecycle" -> AppLifecycle(
+                    AppLifecycle.AppLifecycleData.fromJson(json),
+                    timestamp
+                )
+
+                "network.request" -> NetworkRequest(NetworkRequest.NetworkRequestData.fromJson(json))
+                "network.state" -> NetworkState(NetworkState.NetworkStateData.fromJson(json))
+                "user.event" -> UserEvent(UserEvent.UserEventData.fromJson(json))
+                "app.install" -> AppInstall(AppInstall.AppInstallData.fromJson(json))
+                "app.update" -> AppUpdate(AppUpdate.AppUpdateData.fromJson(json))
+                else -> null
+            }
+        }
+    }
+
     class UiLifecycle(data: UiLifecycleData) :
         BreadcrumbEvent("ui.lifecycle", System.currentTimeMillis(), data) {
         data class UiLifecycleData(
@@ -26,6 +48,15 @@ internal sealed class BreadcrumbEvent(
             override fun writeTo(jsonObject: JSONObject) {
                 jsonObject.put("className", className)
                 jsonObject.put("event", event)
+            }
+
+            companion object {
+                fun fromJson(json: JSONObject): UiLifecycleData {
+                    return UiLifecycleData(
+                        className = json.getString("className"),
+                        event = json.getString("event")
+                    )
+                }
             }
         }
     }
@@ -40,6 +71,15 @@ internal sealed class BreadcrumbEvent(
                 jsonObject.put("eventType", eventType)
                 jsonObject.put("event", event)
             }
+
+            companion object {
+                fun fromJson(json: JSONObject): SystemEventData {
+                    return SystemEventData(
+                        eventType = json.getString("eventType"),
+                        event = json.getString("event")
+                    )
+                }
+            }
         }
     }
 
@@ -50,6 +90,14 @@ internal sealed class BreadcrumbEvent(
         ) : Data {
             override fun writeTo(jsonObject: JSONObject) {
                 jsonObject.put("event", event)
+            }
+
+            companion object {
+                fun fromJson(json: JSONObject): AppLifecycleData {
+                    return AppLifecycleData(
+                        event = json.getString("event")
+                    )
+                }
             }
         }
     }
@@ -64,6 +112,15 @@ internal sealed class BreadcrumbEvent(
                 jsonObject.put("url", url)
                 jsonObject.put("statusCode", statusCode.toString())
             }
+
+            companion object {
+                fun fromJson(json: JSONObject): NetworkRequestData {
+                    return NetworkRequestData(
+                        url = json.getString("url"),
+                        statusCode = json.getString("statusCode").toInt()
+                    )
+                }
+            }
         }
     }
 
@@ -74,6 +131,14 @@ internal sealed class BreadcrumbEvent(
         ) : Data {
             override fun writeTo(jsonObject: JSONObject) {
                 jsonObject.put("state", state)
+            }
+
+            companion object {
+                fun fromJson(json: JSONObject): NetworkStateData {
+                    return NetworkStateData(
+                        state = json.getString("state")
+                    )
+                }
             }
         }
     }
@@ -98,6 +163,18 @@ internal sealed class BreadcrumbEvent(
                 jsonObject.put("x", x.toString())
                 jsonObject.put("y", y.toString())
             }
+
+            companion object {
+                fun fromJson(json: JSONObject): UserEventData {
+                    return UserEventData(
+                        action = json.getString("action"),
+                        targetClass = json.optString("targetClass", null),
+                        targetId = json.optString("targetId", null),
+                        x = json.getString("x").toFloat(),
+                        y = json.getString("y").toFloat()
+                    )
+                }
+            }
         }
     }
 
@@ -108,6 +185,14 @@ internal sealed class BreadcrumbEvent(
         ) : Data {
             override fun writeTo(jsonObject: JSONObject) {
                 jsonObject.put("version", version)
+            }
+
+            companion object {
+                fun fromJson(json: JSONObject): AppInstallData {
+                    return AppInstallData(
+                        version = json.getString("version")
+                    )
+                }
             }
         }
     }
@@ -121,6 +206,15 @@ internal sealed class BreadcrumbEvent(
             override fun writeTo(jsonObject: JSONObject) {
                 jsonObject.put("from", from)
                 jsonObject.put("to", to)
+            }
+
+            companion object {
+                fun fromJson(json: JSONObject): AppUpdateData {
+                    return AppUpdateData(
+                        from = json.getString("from"),
+                        to = json.getString("to")
+                    )
+                }
             }
         }
     }

--- a/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsCollector.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsCollector.kt
@@ -1,15 +1,42 @@
 package com.bluetriangle.analytics.breadcrumbs
 
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.bluetriangle.analytics.Constants.BREADCRUMBS
 import com.bluetriangle.analytics.Tracker
+import com.bluetriangle.analytics.Tracker.Companion.SHARED_PREFERENCES_NAME
 import org.json.JSONArray
 import org.json.JSONObject
+import java.lang.ref.WeakReference
 
-internal class BreadcrumbsCollector (
-    private val capacity: Int
+internal class BreadcrumbsCollector(
+    private val capacity: Int, private val context: WeakReference<Context>
 ) {
     private val buffer = arrayOfNulls<JSONObject>(capacity)
     private var head = 0
     private var size = 0
+
+    private val prefs: SharedPreferences?
+        get() {
+            val context = context.get() ?: return null
+            return context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
+        }
+
+    init {
+        // Load cached breadcrumbs from SharedPreferences
+        val cachedBreadcrumbs = prefs?.getString(BREADCRUMBS, null)
+        cachedBreadcrumbs?.let {
+            try {
+                val jsonArray = JSONArray(it)
+                for (i in 0 until jsonArray.length()) {
+                    val jsonObject = jsonArray.getJSONObject(i)
+                    BreadcrumbEvent.fromJson(jsonObject)?.let { breadcrumb -> add(breadcrumb) }
+                }
+            } catch (e: Exception) {
+            }
+        }
+    }
 
     @Synchronized
     fun add(item: BreadcrumbEvent) {
@@ -46,4 +73,12 @@ internal class BreadcrumbsCollector (
     fun currentSize(): Int = size
 
     fun capacity(): Int = capacity
+
+    @Synchronized
+    fun dump() {
+        val breadcrumbs = snapshot()?.toString() ?: ""
+        prefs?.edit {
+            putString(BREADCRUMBS, breadcrumbs)
+        }
+    }
 }

--- a/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsCollector.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsCollector.kt
@@ -63,6 +63,27 @@ internal class BreadcrumbsCollector(
     }
 
     @Synchronized
+    fun getCachedSnapshot(): JSONArray {
+        val result = JSONArray()
+
+        val existingBreadcrumbs = prefs?.getString(BREADCRUMBS, null)
+        existingBreadcrumbs?.let {
+            try {
+                val jsonArray = JSONArray(it)
+                for (i in 0 until jsonArray.length()) {
+                    val jsonObject = jsonArray.getJSONObject(i)
+                    result.put(jsonObject)
+                    BreadcrumbEvent.fromJson(jsonObject)
+                        ?.let { breadcrumb -> result.put(breadcrumb) }
+                }
+            } catch (e: Exception) {
+            }
+        }
+
+        return result
+    }
+
+    @Synchronized
     fun clear() {
         head = 0
         size = 0

--- a/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsManager.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsManager.kt
@@ -1,5 +1,6 @@
 package com.bluetriangle.analytics.breadcrumbs
 
+import android.content.Context
 import com.bluetriangle.analytics.breadcrumbs.config.BreadcrumbsConfig
 import com.bluetriangle.analytics.breadcrumbs.config.BreadcrumbsFeature
 import com.bluetriangle.analytics.breadcrumbs.instrumentation.AppInstallInstrumentation
@@ -12,15 +13,16 @@ import com.bluetriangle.analytics.breadcrumbs.instrumentation.SystemEventsInstru
 import com.bluetriangle.analytics.breadcrumbs.instrumentation.UiLifecycleInstrumentation
 import com.bluetriangle.analytics.breadcrumbs.instrumentation.UserEventInstrumentation
 import org.json.JSONArray
+import java.lang.ref.WeakReference
 
-internal class BreadcrumbsManager(var config: BreadcrumbsConfig, private val shouldDetectTap: Boolean) {
+internal class BreadcrumbsManager(var config: BreadcrumbsConfig, private val shouldDetectTap: Boolean, private val context: WeakReference<Context>) {
     private var breadcrumbsCollector: BreadcrumbsCollector? = null
     private var instrumentations: MutableMap<BreadcrumbsFeature, BreadcrumbInstrumentation> = mutableMapOf()
 
     private var features = BreadcrumbsFeature.values().filterNot { config.ignoredFeatures.contains(it) }
 
     fun install() {
-        breadcrumbsCollector = BreadcrumbsCollector(config.capacity)
+        breadcrumbsCollector = BreadcrumbsCollector(config.capacity, context)
 
         breadcrumbsCollector?.let { collector ->
             instrumentations = features.associateWith {
@@ -79,4 +81,7 @@ internal class BreadcrumbsManager(var config: BreadcrumbsConfig, private val sho
         return breadcrumbsCollector?.snapshot()
     }
 
+    fun dump() {
+        breadcrumbsCollector?.dump()
+    }
 }

--- a/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsManager.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsManager.kt
@@ -13,7 +13,7 @@ import com.bluetriangle.analytics.breadcrumbs.instrumentation.UiLifecycleInstrum
 import com.bluetriangle.analytics.breadcrumbs.instrumentation.UserEventInstrumentation
 import org.json.JSONArray
 
-internal class BreadcrumbsManager(var config: BreadcrumbsConfig) {
+internal class BreadcrumbsManager(var config: BreadcrumbsConfig, private val shouldDetectTap: Boolean) {
     private var breadcrumbsCollector: BreadcrumbsCollector? = null
     private var instrumentations: MutableMap<BreadcrumbsFeature, BreadcrumbInstrumentation> = mutableMapOf()
 
@@ -29,7 +29,7 @@ internal class BreadcrumbsManager(var config: BreadcrumbsConfig) {
         }
 
         instrumentations.values.forEach {
-            it.enable()
+            if (it !is UserEventInstrumentation || shouldDetectTap) it.enable()
         }
     }
 
@@ -53,7 +53,7 @@ internal class BreadcrumbsManager(var config: BreadcrumbsConfig) {
         BreadcrumbsFeature.SystemEvent -> SystemEventsInstrumentation(collector)
     }
 
-    fun updateConfig(config: BreadcrumbsConfig) {
+    fun updateConfig(config: BreadcrumbsConfig, shouldDetectTap: Boolean) {
         val collector = breadcrumbsCollector?: return
         val newFeatures = BreadcrumbsFeature.values().filterNot { config.ignoredFeatures.contains(it) }
         val toBeDisabled = features.filterNot { newFeatures.contains(it) }
@@ -65,7 +65,13 @@ internal class BreadcrumbsManager(var config: BreadcrumbsConfig) {
         }
         toBeEnabled.forEach {
             instrumentations[it] = featureToInstrumentation(it, collector)
-            instrumentations[it]?.enable()
+            // Enable User Event only if tap tracking is enabled
+            if (it == BreadcrumbsFeature.UserEvent && !shouldDetectTap) {
+                instrumentations[it]?.disable()
+                instrumentations.remove(it)
+            } else {
+                instrumentations[it]?.enable()
+            }
         }
     }
 

--- a/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsManager.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsManager.kt
@@ -81,6 +81,10 @@ internal class BreadcrumbsManager(var config: BreadcrumbsConfig, private val sho
         return breadcrumbsCollector?.snapshot()
     }
 
+    fun getCachedSnapshot(): JSONArray? {
+        return breadcrumbsCollector?.getCachedSnapshot()
+    }
+
     fun dump() {
         breadcrumbsCollector?.dump()
     }

--- a/analytics/src/main/java/com/bluetriangle/analytics/dynamicconfig/model/BTTRemoteConfiguration.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/dynamicconfig/model/BTTRemoteConfiguration.kt
@@ -24,7 +24,10 @@ internal open class BTTRemoteConfiguration(
     val enableWebViewStitching: Boolean,
     val checkoutConfig: CheckoutConfig,
     val breadcrumbsConfig: BreadcrumbsConfig,
-    val configKey: String
+    val configKey: String,
+    val enableAppInstall: Boolean,
+    val enableForceRestart: Boolean,
+    val forceRestartDuration: Double
 ) {
     override fun equals(other: Any?): Boolean {
         if(other is BTTRemoteConfiguration) {
@@ -43,7 +46,10 @@ internal open class BTTRemoteConfiguration(
                     other.enableWebViewStitching == enableWebViewStitching &&
                     other.checkoutConfig == checkoutConfig &&
                     other.breadcrumbsConfig == breadcrumbsConfig &&
-                    other.configKey == configKey
+                    other.configKey == configKey &&
+                    other.enableAppInstall == enableAppInstall &&
+                    other.enableForceRestart == enableForceRestart &&
+                    other.forceRestartDuration == forceRestartDuration
         }
         return false
     }
@@ -69,6 +75,9 @@ internal open class BTTRemoteConfiguration(
         result = 31 * result + checkoutConfig.hashCode()
         result = 31 * result + breadcrumbsConfig.hashCode()
         result = 31 * result + configKey.hashCode()
+        result = 31 * result + enableAppInstall.hashCode()
+        result = 31 * result + enableForceRestart.hashCode()
+        result = 31 * result + forceRestartDuration.hashCode()
         return result
     }
 

--- a/analytics/src/main/java/com/bluetriangle/analytics/dynamicconfig/model/BTTRemoteConfigurationMapper.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/dynamicconfig/model/BTTRemoteConfigurationMapper.kt
@@ -7,12 +7,15 @@ package com.bluetriangle.analytics.dynamicconfig.model
 
 import com.bluetriangle.analytics.Constants.DEFAULT_CONFIG_KEY
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_ANR_TRACKING
+import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_APP_INSTALL
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_CRASH_TRACKING
+import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_FORCE_RESTART
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_GROUPING
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_LAUNCH_TIME
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_MEMORY_WARNING
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_NETWORK_STATE_TRACKING
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_WEB_VIEW_STITCHING
+import com.bluetriangle.analytics.Constants.DEFAULT_FORCE_RESTART_DURATION
 import com.bluetriangle.analytics.Constants.DEFAULT_GROUPING_IDLE_TIME
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_GROUPING_TAP_DETECTION
 import com.bluetriangle.analytics.breadcrumbs.config.BreadcrumbsConfigMapper
@@ -41,6 +44,9 @@ internal object BTTRemoteConfigurationMapper {
     private const val ENABLE_LAUNCH_TIME = "enableLaunchTime"
     private const val ENABLE_WEB_VIEW_STITCHING = "enableWebViewStitching"
     private const val CONFIG_KEY = "configKey"
+    private const val ENABLE_APP_INSTALL = "enableAppInstall"
+    private const val ENABLE_FORCE_RESTART = "enableForceRestart"
+    private const val FORCE_RESTART_DURATION = "forceRestartDuration"
 
     fun fromJson(remoteConfigJson: JSONObject): BTTRemoteConfiguration {
         val networkSampleRate = remoteConfigJson.getDoubleOrNull(NETWORK_SAMPLE_RATE)?.div(100.0)
@@ -68,7 +74,12 @@ internal object BTTRemoteConfigurationMapper {
         val checkoutConfig = CheckoutConfigMapper.loadFromJsonObject(remoteConfigJson)
         val breadcrumbsConfig = BreadcrumbsConfigMapper.loadFromJsonObject(remoteConfigJson)
         val configKey = remoteConfigJson.getStringOrNull(CONFIG_KEY) ?: DEFAULT_CONFIG_KEY
-
+        val enableAppInstall =
+            remoteConfigJson.getBooleanOrNull(ENABLE_APP_INSTALL) ?: DEFAULT_ENABLE_APP_INSTALL
+        val enableForceRestart =
+            remoteConfigJson.getBooleanOrNull(ENABLE_FORCE_RESTART) ?: DEFAULT_ENABLE_FORCE_RESTART
+        val forceRestartDuration =
+            remoteConfigJson.getDoubleOrNull(FORCE_RESTART_DURATION) ?: DEFAULT_FORCE_RESTART_DURATION
         return BTTRemoteConfiguration(
             networkSampleRate,
             ignoreScreens,
@@ -85,7 +96,10 @@ internal object BTTRemoteConfigurationMapper {
             enableWebViewStitching,
             checkoutConfig,
             breadcrumbsConfig,
-            configKey
+            configKey,
+            enableAppInstall,
+            enableForceRestart,
+            forceRestartDuration
         )
     }
 }

--- a/analytics/src/main/java/com/bluetriangle/analytics/dynamicconfig/model/BTTSavedRemoteConfiguration.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/dynamicconfig/model/BTTSavedRemoteConfiguration.kt
@@ -25,7 +25,10 @@ internal class BTTSavedRemoteConfiguration(
     checkoutConfig: CheckoutConfig,
     breadcrumbsConfig: BreadcrumbsConfig,
     configKey: String,
-    val savedDate: Long
+    val savedDate: Long,
+    enableAppInstall: Boolean,
+    enableForceRestart: Boolean,
+    forceRestartDuration: Double
 ) : BTTRemoteConfiguration(
     networkSampleRate,
     ignoreScreens,
@@ -42,7 +45,10 @@ internal class BTTSavedRemoteConfiguration(
     enableWebViewStitching,
     checkoutConfig,
     breadcrumbsConfig,
-    configKey
+    configKey,
+    enableAppInstall,
+    enableForceRestart,
+    forceRestartDuration
 ) {
 
     companion object {
@@ -63,7 +69,10 @@ internal class BTTSavedRemoteConfiguration(
             remoteConfig.checkoutConfig,
             remoteConfig.breadcrumbsConfig,
             remoteConfig.configKey,
-            System.currentTimeMillis()
+            System.currentTimeMillis(),
+            remoteConfig.enableAppInstall,
+            remoteConfig.enableForceRestart,
+            remoteConfig.forceRestartDuration
         )
     }
 

--- a/analytics/src/main/java/com/bluetriangle/analytics/dynamicconfig/model/BTTSavedRemoteConfigurationMapper.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/dynamicconfig/model/BTTSavedRemoteConfigurationMapper.kt
@@ -8,13 +8,16 @@ package com.bluetriangle.analytics.dynamicconfig.model
 import com.bluetriangle.analytics.Constants
 import com.bluetriangle.analytics.Constants.DEFAULT_CONFIG_KEY
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_ANR_TRACKING
+import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_APP_INSTALL
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_CRASH_TRACKING
+import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_FORCE_RESTART
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_GROUPING
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_GROUPING_TAP_DETECTION
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_LAUNCH_TIME
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_MEMORY_WARNING
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_NETWORK_STATE_TRACKING
 import com.bluetriangle.analytics.Constants.DEFAULT_ENABLE_WEB_VIEW_STITCHING
+import com.bluetriangle.analytics.Constants.DEFAULT_FORCE_RESTART_DURATION
 import com.bluetriangle.analytics.breadcrumbs.config.BreadcrumbsConfigMapper
 import com.bluetriangle.analytics.checkout.config.CheckoutConfigMapper
 import com.bluetriangle.analytics.utility.getBooleanOrNull
@@ -40,6 +43,9 @@ internal object BTTSavedRemoteConfigurationMapper {
     private const val ENABLE_MEMORY_WARNING = "enableMemoryWarning"
     private const val ENABLE_LAUNCH_TIME = "enableLaunchTime"
     private const val ENABLE_WEB_VIEW_STITCHING = "enableWebViewStitching"
+    private const val ENABLE_APP_INSTALL = "enableAppInstall"
+    private const val ENABLE_FORCE_RESTART = "enableForceRestart"
+    private const val FORCE_RESTART_DURATION = "forceRestartDuration"
 
     private const val CONFIG_KEY = "configKey"
 
@@ -71,7 +77,10 @@ internal object BTTSavedRemoteConfigurationMapper {
             CheckoutConfigMapper.loadFromJsonObject(jsonObject),
             BreadcrumbsConfigMapper.loadFromJsonObject(jsonObject),
             jsonObject.getStringOrNull(CONFIG_KEY) ?: DEFAULT_CONFIG_KEY,
-            jsonObject.getLong(SAVED_DATE)
+            jsonObject.getLong(SAVED_DATE),
+            jsonObject.getBooleanOrNull(ENABLE_APP_INSTALL) ?: DEFAULT_ENABLE_APP_INSTALL,
+            jsonObject.getBooleanOrNull(ENABLE_FORCE_RESTART) ?: DEFAULT_ENABLE_FORCE_RESTART,
+            jsonObject.getDoubleOrNull(FORCE_RESTART_DURATION) ?: DEFAULT_FORCE_RESTART_DURATION
         )
     }
 
@@ -97,6 +106,9 @@ internal object BTTSavedRemoteConfigurationMapper {
         BreadcrumbsConfigMapper.loadIntoJsonObject(this, config.breadcrumbsConfig)
         put(CONFIG_KEY, config.configKey)
         put(SAVED_DATE, config.savedDate)
+        put(ENABLE_APP_INSTALL, config.enableAppInstall)
+        put(ENABLE_FORCE_RESTART, config.enableForceRestart)
+        put(FORCE_RESTART_DURATION, config.forceRestartDuration)
     }
 
 }

--- a/analytics/src/main/java/com/bluetriangle/analytics/event/BTTEvent.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/event/BTTEvent.kt
@@ -10,6 +10,7 @@ sealed class BTTEvent(val id: Int, val defaultPageName: String): Parcelable {
     object HotLaunch: BTTEvent(3, "HotLaunchTime")
     object ANRWarning: BTTEvent(4, "ANRWarning")
     object MemoryWarning: BTTEvent(5, "MemoryWarning")
-    object Crash: BTTEvent(7, "NativeAppCrash") // 8 is for iOS crash
+    object Crash: BTTEvent(7, "NativeAppCrash") // 6 is for iOS crash
     object AppInstall: BTTEvent(8, "AppInstall")
+    object ForceRestart: BTTEvent(9, "ForceRestart")
 }

--- a/analytics/src/main/java/com/bluetriangle/analytics/event/BTTEvent.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/event/BTTEvent.kt
@@ -10,6 +10,6 @@ sealed class BTTEvent(val id: Int, val defaultPageName: String): Parcelable {
     object HotLaunch: BTTEvent(3, "HotLaunchTime")
     object ANRWarning: BTTEvent(4, "ANRWarning")
     object MemoryWarning: BTTEvent(5, "MemoryWarning")
-    object Crash: BTTEvent(7, "Android Crash")
-
+    object Crash: BTTEvent(7, "NativeAppCrash") // 8 is for iOS crash
+    object AppInstall: BTTEvent(8, "AppInstall")
 }

--- a/analytics/src/main/java/com/bluetriangle/analytics/model/NativeAppProperties.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/model/NativeAppProperties.kt
@@ -11,6 +11,7 @@ import com.bluetriangle.analytics.Constants.FULL_TIME
 import com.bluetriangle.analytics.Constants.GROUPED
 import com.bluetriangle.analytics.Constants.GROUPING_CAUSE
 import com.bluetriangle.analytics.Constants.GROUPING_CAUSE_INTERVAL
+import com.bluetriangle.analytics.Constants.INSTALL_TIME
 import com.bluetriangle.analytics.Constants.LAUNCH_SCREEN_NAME
 import com.bluetriangle.analytics.Constants.LOAD_TIME
 import com.bluetriangle.analytics.Constants.MAX_MAIN_THREAD_USAGE
@@ -59,7 +60,8 @@ internal data class NativeAppProperties(
     var className: String = "",
     var event: BTTEvent? = null,
     var autoCheckout: Boolean? = null,
-    var configKey: String? = null
+    var configKey: String? = null,
+    var installTime: Long? = null
 ) : Parcelable {
 
     private val cellularTotal
@@ -80,7 +82,9 @@ internal data class NativeAppProperties(
         obj.put(GROUPING_CAUSE, groupingCause)
         obj.put(GROUPING_CAUSE_INTERVAL, groupingCauseInterval)
         obj.put(EVENT_ID, event?.id?.toString())
-
+        installTime?.let {
+            obj.put(INSTALL_TIME, it)
+        }
         autoCheckout?.let {
             obj.put(AUTO_CHECKOUT, it)
         }

--- a/analytics/src/main/java/com/bluetriangle/analytics/screenTracking/BTTScreenLifecycleTracker.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/screenTracking/BTTScreenLifecycleTracker.kt
@@ -108,7 +108,7 @@ internal class BTTScreenLifecycleTracker(
             timer.end().submit()
         }
 
-        Tracker.instance?.onScreenPause()
+        Tracker.instance?.onScreenPause(timer)
 
         timers.remove(scr)
     }
@@ -151,6 +151,11 @@ internal class BTTScreenLifecycleTracker(
         if(tracker == null || !tracker.isGlobalFieldSet(Timer.FIELD_TRAFFIC_SEGMENT_NAME)) {
             timer.setTrafficSegmentName(AUTOMATED_TIMERS_TRAFFIC_SEGMENT)
         }
+
+        if (timer.getField(Timer.FIELD_TRAFFIC_SEGMENT_NAME) == null || timer.getField(Timer.FIELD_TRAFFIC_SEGMENT_NAME) == "null") {
+            timer.setTrafficSegmentName(AUTOMATED_TIMERS_TRAFFIC_SEGMENT)
+        }
+
         timer.pageTimeCalculator = {
             (pgTm).coerceAtLeast(TIMER_MIN_PGTM)
         }

--- a/analytics/src/main/java/com/bluetriangle/analytics/screenTracking/BTTScreenLifecycleTracker.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/screenTracking/BTTScreenLifecycleTracker.kt
@@ -107,6 +107,9 @@ internal class BTTScreenLifecycleTracker(
         } else {
             timer.end().submit()
         }
+
+        Tracker.instance?.onScreenPause()
+
         timers.remove(scr)
     }
 

--- a/analytics/src/main/java/com/bluetriangle/analytics/sessionmanager/DisabledModeSessionManager.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/sessionmanager/DisabledModeSessionManager.kt
@@ -39,7 +39,10 @@ internal class DisabledModeSessionManager(
         checkoutConfig = CheckoutConfig.DEFAULT,
         breadcrumbsConfig = BreadcrumbsConfig.DEFAULT,
         configKey = DEFAULT_CONFIG_KEY,
-        expiration = 0L
+        expiration = 0L,
+        enableAppInstall = false,
+        enableForceRestart = false,
+        forceRestartDuration = 10.0
     )
 
     override val sessionData: SessionData

--- a/analytics/src/main/java/com/bluetriangle/analytics/sessionmanager/SessionData.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/sessionmanager/SessionData.kt
@@ -49,7 +49,10 @@ internal data class SessionData(
     val checkoutConfig: CheckoutConfig,
     val breadcrumbsConfig: BreadcrumbsConfig,
     val configKey: String,
-    val expiration: Long
+    val expiration: Long,
+    val enableAppInstall: Boolean,
+    val enableForceRestart: Boolean,
+    val forceRestartDuration: Double
 ) {
     companion object {
         private const val SESSION_ID = "sessionId"
@@ -68,6 +71,9 @@ internal data class SessionData(
         private const val ENABLE_MEMORY_WARNING = "enableMemoryWarning"
         private const val ENABLE_LAUNCH_TIME = "enableLaunchTime"
         private const val ENABLE_WEB_VIEW_STITCHING = "enableWebViewStitching"
+        private const val ENABLE_APP_INSTALL = "enableAppInstall"
+        private const val ENABLE_FORCE_RESTART = "enableForceRestart"
+        private const val FORCE_RESTART_DURATION = "forceRestartDuration"
 
         internal fun JSONObject.toSessionData(): SessionData? {
             try {
@@ -96,7 +102,10 @@ internal data class SessionData(
                     checkoutConfig = CheckoutConfigMapper.loadFromJsonObject(this),
                     breadcrumbsConfig = BreadcrumbsConfigMapper.loadFromJsonObject(this),
                     configKey = getStringOrNull(CONFIG_KEY) ?: DEFAULT_CONFIG_KEY,
-                    expiration = getLong(EXPIRATION)
+                    expiration = getLong(EXPIRATION),
+                    enableAppInstall = getBooleanOrNull(ENABLE_APP_INSTALL) ?: false,
+                    enableForceRestart = getBooleanOrNull(ENABLE_FORCE_RESTART) ?: false,
+                    forceRestartDuration = getDoubleOrNull(FORCE_RESTART_DURATION) ?: 10.0
                 )
             } catch (e: Exception) {
                 Tracker.instance?.configuration?.logger?.error("Error while parsing session data: ${e::class.simpleName}(\"${e.message}\")")
@@ -124,6 +133,9 @@ internal data class SessionData(
             CheckoutConfigMapper.loadIntoJsonObject(this, checkoutConfig)
             BreadcrumbsConfigMapper.loadIntoJsonObject(this, breadcrumbsConfig)
             put(EXPIRATION, expiration)
+            put(ENABLE_APP_INSTALL, enableAppInstall)
+            put(ENABLE_FORCE_RESTART, enableForceRestart)
+            put(FORCE_RESTART_DURATION, forceRestartDuration)
         }
     }
 }

--- a/analytics/src/main/java/com/bluetriangle/analytics/sessionmanager/SessionManager.kt
+++ b/analytics/src/main/java/com/bluetriangle/analytics/sessionmanager/SessionManager.kt
@@ -107,7 +107,10 @@ internal class SessionManager(
             config.checkoutConfig,
             config.breadcrumbsConfig,
             config.configKey,
-            getNewExpiration()
+            getNewExpiration(),
+            config.enableAppInstall,
+            config.enableForceRestart,
+            config.forceRestartDuration
         )
     }
 
@@ -147,7 +150,10 @@ internal class SessionManager(
                 it.checkoutConfig,
                 it.breadcrumbsConfig,
                 it.configKey,
-                getNewExpiration()
+                getNewExpiration(),
+                it.enableAppInstall,
+                it.enableForceRestart,
+                it.forceRestartDuration
             )
             sessionStore.storeSessionData(
                 newExpirySession
@@ -200,7 +206,10 @@ internal class SessionManager(
                                 config.checkoutConfig,
                                 config.breadcrumbsConfig,
                                 config.configKey,
-                                session.expiration
+                                session.expiration,
+                                config.enableAppInstall,
+                                config.enableForceRestart,
+                                config.forceRestartDuration
                             )
                             Tracker.instance?.updateSession(sessionData)
                             sessionStore.storeSessionData(

--- a/analytics/src/test/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsManagerTest.kt
+++ b/analytics/src/test/java/com/bluetriangle/analytics/breadcrumbs/BreadcrumbsManagerTest.kt
@@ -1,5 +1,6 @@
 package com.bluetriangle.analytics.breadcrumbs
 
+import android.content.Context
 import com.bluetriangle.analytics.breadcrumbs.config.BreadcrumbsConfig
 import com.bluetriangle.analytics.breadcrumbs.config.BreadcrumbsFeature
 import com.bluetriangle.analytics.breadcrumbs.instrumentation.AppInstallInstrumentation
@@ -17,10 +18,18 @@ import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.anyBoolean
+import java.lang.ref.WeakReference
 
 class BreadcrumbsManagerTest {
 
-     private fun configWith(vararg active: BreadcrumbsFeature): BreadcrumbsConfig {
+    @Mock
+    private lateinit var mockContext: WeakReference<Context>
+
+    private var shouldDetectTap: Boolean = anyBoolean()
+
+    private fun configWith(vararg active: BreadcrumbsFeature): BreadcrumbsConfig {
         val allFeatures = BreadcrumbsFeature.values().toSet()
         val ignored = allFeatures - active.toSet()
         return BreadcrumbsConfig(true, 100, ignoredFeatures = ignored.toList())
@@ -29,7 +38,7 @@ class BreadcrumbsManagerTest {
     private fun configAllFeatures() = BreadcrumbsConfig(true, 100, ignoredFeatures = emptyList())
 
     private fun spyManagerWithMockedInstrumentations(config: BreadcrumbsConfig): BreadcrumbsManager {
-        val manager = spyk(BreadcrumbsManager(config))
+        val manager = spyk(BreadcrumbsManager(config, shouldDetectTap, mockContext))
         every { manager.featureToInstrumentation(any(), any()) } answers {
             // Return a unique mock per invocation so each feature gets its own mock.
             mockk(relaxed = true)
@@ -103,7 +112,7 @@ class BreadcrumbsManagerTest {
         clearMocks(manager, answers = false, recordedCalls = true)
 
         val newConfig = configWith(BreadcrumbsFeature.AppLifecycle, BreadcrumbsFeature.NetworkState)
-        manager.updateConfig(newConfig)
+        manager.updateConfig(newConfig, shouldDetectTap)
         verify(exactly = 0) { manager.featureToInstrumentation(BreadcrumbsFeature.AppLifecycle, any()) }
         verify(exactly = 1) { manager.featureToInstrumentation(BreadcrumbsFeature.NetworkState, any()) }
     }
@@ -120,7 +129,7 @@ class BreadcrumbsManagerTest {
         clearMocks(manager, answers = false, recordedCalls = true)
 
         val newConfig = configWith(BreadcrumbsFeature.AppLifecycle)
-        manager.updateConfig(newConfig)
+        manager.updateConfig(newConfig, shouldDetectTap)
 
         verify(exactly = 0) { manager.featureToInstrumentation(BreadcrumbsFeature.NetworkState, any()) }
         verify(exactly = 0) { manager.featureToInstrumentation(BreadcrumbsFeature.NetworkState, any()) }
@@ -136,7 +145,7 @@ class BreadcrumbsManagerTest {
 
         clearMocks(manager, answers = false, recordedCalls = true)
 
-        manager.updateConfig(configWith(BreadcrumbsFeature.AppLifecycle))
+        manager.updateConfig(configWith(BreadcrumbsFeature.AppLifecycle), shouldDetectTap)
         verify(exactly = 0) { manager.featureToInstrumentation(BreadcrumbsFeature.AppLifecycle, any()) }
 
     }
@@ -145,14 +154,14 @@ class BreadcrumbsManagerTest {
     fun `updateConfig - before install is called - does nothing`() {
         val manager = spyManagerWithMockedInstrumentations(configAllFeatures())
 
-        manager.updateConfig(configAllFeatures())
+        manager.updateConfig(configAllFeatures(), shouldDetectTap)
 
         verify(exactly = 0) { manager.featureToInstrumentation(any(), any()) }
     }
 
     @Test
     fun `featureToInstrumentation - AppLifecycle - returns AppLifecycleInstrumentation`() {
-        val manager = BreadcrumbsManager(configAllFeatures())
+        val manager = BreadcrumbsManager(configAllFeatures(), shouldDetectTap, mockContext)
         val collector = mockk<BreadcrumbsCollector>(relaxed = true)
 
         val instrumentation = manager.featureToInstrumentation(BreadcrumbsFeature.AppLifecycle, collector)
@@ -162,7 +171,7 @@ class BreadcrumbsManagerTest {
 
     @Test
     fun `featureToInstrumentation - UiLifecycle - returns UiLifecycleInstrumentation`() {
-        val manager = BreadcrumbsManager(configAllFeatures())
+        val manager = BreadcrumbsManager(configAllFeatures(), shouldDetectTap, mockContext)
         val collector = mockk<BreadcrumbsCollector>(relaxed = true)
 
         assertTrue(manager.featureToInstrumentation(BreadcrumbsFeature.UiLifecycle, collector) is UiLifecycleInstrumentation)
@@ -170,7 +179,7 @@ class BreadcrumbsManagerTest {
 
     @Test
     fun `featureToInstrumentation - NetworkRequest - returns NetworkRequestInstrumentation`() {
-        val manager = BreadcrumbsManager(configAllFeatures())
+        val manager = BreadcrumbsManager(configAllFeatures(), shouldDetectTap, mockContext)
         val collector = mockk<BreadcrumbsCollector>(relaxed = true)
 
         assertTrue(manager.featureToInstrumentation(BreadcrumbsFeature.NetworkRequest, collector) is NetworkRequestInstrumentation)
@@ -178,7 +187,7 @@ class BreadcrumbsManagerTest {
 
     @Test
     fun `featureToInstrumentation - NetworkState - returns NetworkStateInstrumentation`() {
-        val manager = BreadcrumbsManager(configAllFeatures())
+        val manager = BreadcrumbsManager(configAllFeatures(), shouldDetectTap, mockContext)
         val collector = mockk<BreadcrumbsCollector>(relaxed = true)
 
         assertTrue(manager.featureToInstrumentation(BreadcrumbsFeature.NetworkState, collector) is NetworkStateInstrumentation)
@@ -186,7 +195,7 @@ class BreadcrumbsManagerTest {
 
     @Test
     fun `featureToInstrumentation - AppInstall - returns AppInstallInstrumentation`() {
-        val manager = BreadcrumbsManager(configAllFeatures())
+        val manager = BreadcrumbsManager(configAllFeatures(), shouldDetectTap, mockContext)
         val collector = mockk<BreadcrumbsCollector>(relaxed = true)
 
         assertTrue(manager.featureToInstrumentation(BreadcrumbsFeature.AppInstall, collector) is AppInstallInstrumentation)
@@ -194,7 +203,7 @@ class BreadcrumbsManagerTest {
 
     @Test
     fun `featureToInstrumentation - AppUpdate - returns AppUpdateInstrumentation`() {
-        val manager = BreadcrumbsManager(configAllFeatures())
+        val manager = BreadcrumbsManager(configAllFeatures(), shouldDetectTap, mockContext)
         val collector = mockk<BreadcrumbsCollector>(relaxed = true)
 
         assertTrue(manager.featureToInstrumentation(BreadcrumbsFeature.AppUpdate, collector) is AppUpdateInstrumentation)
@@ -202,7 +211,7 @@ class BreadcrumbsManagerTest {
 
     @Test
     fun `featureToInstrumentation - UserEvent - returns UserEventInstrumentation`() {
-        val manager = BreadcrumbsManager(configAllFeatures())
+        val manager = BreadcrumbsManager(configAllFeatures(), shouldDetectTap, mockContext)
         val collector = mockk<BreadcrumbsCollector>(relaxed = true)
 
         assertTrue(manager.featureToInstrumentation(BreadcrumbsFeature.UserEvent, collector) is UserEventInstrumentation)
@@ -210,7 +219,7 @@ class BreadcrumbsManagerTest {
 
     @Test
     fun `featureToInstrumentation - SystemEvent - returns SystemEventsInstrumentation`() {
-        val manager = BreadcrumbsManager(configAllFeatures())
+        val manager = BreadcrumbsManager(configAllFeatures(), shouldDetectTap, mockContext)
         val collector = mockk<BreadcrumbsCollector>(relaxed = true)
 
         assertTrue(manager.featureToInstrumentation(BreadcrumbsFeature.SystemEvent, collector) is SystemEventsInstrumentation)

--- a/analytics/src/test/java/com/bluetriangle/analytics/dynamicconfig/fetcher/BTTConfigurationFetcherTest.kt
+++ b/analytics/src/test/java/com/bluetriangle/analytics/dynamicconfig/fetcher/BTTConfigurationFetcherTest.kt
@@ -112,7 +112,10 @@ class BTTConfigurationFetcherTest {
                 true,
                 CheckoutConfig.DEFAULT,
                 BreadcrumbsConfig.DEFAULT,
-                ""
+                "",
+                true,
+                true,
+                10.0
             )
             val result = fetcher.fetch()
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         namespace "com.bluetriangle.android.demo"
         minSdk 21
         targetSdk 34
-        versionCode 5
-        versionName "2.19.4"
+        versionCode 6
+        versionName "2.19.5"
 
         externalNativeBuild {
             cmake {


### PR DESCRIPTION
### New Features and Bug Fixes
- App installs tracking: BlueTriangle can now track new app installs.
- App Force Restart Tracking: If the user force restarts the app, kills it, and restarts immediately, BlueTriangle tracks it as Force Restart. User has a tendency to force restart the app if something on the current screen is not working. BlueTriangle can now track this as an error.

### Bug Fixes and Improvements
- Disabling user tap interspersion for groups will also disable it in breadcrumbs.
